### PR TITLE
fix(security): Potential fix for code scanning alert no. 12: Full server-side request forgery

### DIFF
--- a/backend/delivery/slack.py
+++ b/backend/delivery/slack.py
@@ -55,6 +55,7 @@ class SlackService:
             return False
         except Exception:
             return False
+
     def _format_message(
         self, summary: str, repo_name: str, repo_url: str
     ) -> dict[str, Any]:

--- a/backend/delivery/slack.py
+++ b/backend/delivery/slack.py
@@ -1,6 +1,7 @@
 import httpx
 import logging
 from typing import Any
+import urllib.parse
 
 logger = logging.getLogger(__name__)
 
@@ -15,6 +16,10 @@ class SlackService:
             webhook = webhook_url
             if not webhook:
                 raise ValueError("No Slack webhook URL provided")
+
+            if not self._is_valid_slack_webhook_url(webhook):
+                logger.error(f"Invalid Slack webhook URL: {webhook}")
+                return False
 
             message = self._format_message(summary, repo_name, repo_url)
 
@@ -34,6 +39,22 @@ class SlackService:
             logger.error(f"Error sending to Slack: {str(e)}")
             return False
 
+    def _is_valid_slack_webhook_url(self, url: str) -> bool:
+        """
+        Validate that the webhook URL is a Slack webhook endpoint.
+        Only allow URLs with scheme 'https' and netloc 'hooks.slack.com'.
+        """
+        try:
+            parsed = urllib.parse.urlparse(url)
+            if (
+                parsed.scheme == "https"
+                and parsed.netloc == "hooks.slack.com"
+                and parsed.path.startswith("/services/")
+            ):
+                return True
+            return False
+        except Exception:
+            return False
     def _format_message(
         self, summary: str, repo_name: str, repo_url: str
     ) -> dict[str, Any]:


### PR DESCRIPTION
Potential fix for [https://github.com/SaadMukhtar/infrasync/security/code-scanning/12](https://github.com/SaadMukhtar/infrasync/security/code-scanning/12)

To fix this SSRF vulnerability, you should validate the `webhook_url` before using it in an HTTP request. The best approach is to restrict the webhook URL to a known set of allowed domains (e.g., Slack's official webhook endpoint: `https://hooks.slack.com/`). This can be done by checking that the parsed URL's hostname matches the expected value and that the scheme is HTTPS. You should perform this validation in the `send_digest` method of `SlackService` before making the HTTP request. If the validation fails, log an error and return `False` (or raise an exception as appropriate).

**Required changes:**
- In `backend/delivery/slack.py`, add a method to validate the webhook URL.
- Before making the HTTP request, call this validation method.
- If the URL is not valid, log an error and return `False`.
- Import `urllib.parse` for URL parsing.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
